### PR TITLE
check for file first for func get_theme

### DIFF
--- a/gdmshelltheme.in
+++ b/gdmshelltheme.in
@@ -7,14 +7,15 @@ import shutil
 
 def Get_Shell_theme():
 	shell_theme = 'Adwaita'
-	ifile = file('/usr/share/gnome-shell/theme/gnome-shell.css',"r")
-	lines = ifile.readlines()
-	for i in range(len(lines)) :
-		line = lines[i].strip()
-		if line[0:2] == "/*" and line[len(line)-2:len(line)] == "*/" :
-			comment = line[2:len(line)-2]
-			if comment[0:6] == "theme=" :
-				shell_theme = comment[6:len(comment)]
+	if os.path.isfile('/usr/share/gnome-shell/theme/gnome-shell.css'): 
+		ifile = file('/usr/share/gnome-shell/theme/gnome-shell.css',"r")
+		lines = ifile.readlines()
+		for i in range(len(lines)) :
+			line = lines[i].strip()
+			if line[0:2] == "/*" and line[len(line)-2:len(line)] == "*/" :
+				comment = line[2:len(line)-2]
+				if comment[0:6] == "theme=" :
+					shell_theme = comment[6:len(comment)]
 
 	return shell_theme
 


### PR DESCRIPTION
on my installation gnome-shell.css doesn't exist, maybe others idk (i didn't remove that file so maybe it's gnome who did with their package or debian) anyway it's good practice to check for file first (and possibly handle the error) and as long as adwaita is used on other cases i didn't handle an else